### PR TITLE
Fix two crash issues that occur in the process of formatting: IllegalStateException with OffsetMapping.transformedToOriginal

### DIFF
--- a/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/PhoneNumberTransformation.kt
+++ b/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/PhoneNumberTransformation.kt
@@ -107,7 +107,7 @@ internal class PhoneNumberTransformation(
                 } else {
                     originalToTransformed.add(index)
                 }
-                transformedToOriginal.add(index - specialCharsCount)
+                transformedToOriginal.add(maxOf(index - specialCharsCount, 0))
             }
 
             // Ensure both lists have a proper end boundary offset

--- a/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/PhoneNumberTransformation.kt
+++ b/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/PhoneNumberTransformation.kt
@@ -54,13 +54,12 @@ internal class PhoneNumberTransformation(
             AnnotatedString(transformation.formatted ?: text.text),
             object : OffsetMapping {
                 override fun originalToTransformed(offset: Int): Int {
-                    return transformation.originalToTransformed.getOrElse(offset) {
-                        offset // Return the original offset if out of bounds
-                    }
+                    // Return the original offset if out of bounds
+                    return transformation.originalToTransformed[offset.coerceIn(transformation.originalToTransformed.indices)]
                 }
 
                 override fun transformedToOriginal(offset: Int): Int {
-                    return transformation.transformedToOriginal.getOrElse(offset) { -1 }
+                    return transformation.transformedToOriginal[offset.coerceIn(transformation.transformedToOriginal.indices)]
                 }
             },
         )


### PR DESCRIPTION
- Crash occurs when characters other than numbers are entered.
- Crash occurs when i changing the phone number format for certain countries, such as the United States ex) (555) 555-555

This fixes #73 

Please check the link below

https://github.com/joelkanyi/kompose-country-code-picker/issues/73#issuecomment-2601178038






