### PR TITLE
Fix can't search country using translated name

### DIFF
--- a/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/component/CountrySelectionDialog.kt
+++ b/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/component/CountrySelectionDialog.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -92,6 +93,8 @@ public fun CountrySelectionDialog(
         )
     },
 ) {
+    val context = LocalContext.current
+
     var searchValue by remember { mutableStateOf("") }
     var isSearch by remember { mutableStateOf(false) }
     var filteredItems by remember { mutableStateOf(countryList) }
@@ -125,7 +128,7 @@ public fun CountrySelectionDialog(
                                     value = searchValue,
                                     onValueChange = { searchStr ->
                                         searchValue = searchStr
-                                        filteredItems = countryList.searchForAnItem(searchStr)
+                                        filteredItems = countryList.searchForAnItem(searchStr, context)
                                     },
                                     placeholder = {
                                         Text(

--- a/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/CharSequenceExt.kt
+++ b/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/CharSequenceExt.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 Joel Kanyi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.joelkanyi.jcomposecountrycodepicker.utils
 
 import java.text.Normalizer

--- a/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/CharSequenceExt.kt
+++ b/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/CharSequenceExt.kt
@@ -1,0 +1,10 @@
+package com.joelkanyi.jcomposecountrycodepicker.utils
+
+import java.text.Normalizer
+
+private val REGEX_UNACCENT = "\\p{InCombiningDiacriticalMarks}+".toRegex()
+
+internal fun CharSequence.unaccent(): String {
+    val temp = Normalizer.normalize(this, Normalizer.Form.NFD)
+    return REGEX_UNACCENT.replace(temp, "")
+}

--- a/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/PickerUtils.kt
+++ b/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/PickerUtils.kt
@@ -113,8 +113,7 @@ internal object PickerUtils {
             context?.getString(getCountryName(it.code))?.unaccent()?.contains(
                 searchStr,
                 ignoreCase = true,
-            ) ?: false
-                ||
+            ) ?: false ||
                 it.name.unaccent().contains(
                     searchStr,
                     ignoreCase = true,

--- a/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/PickerUtils.kt
+++ b/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/PickerUtils.kt
@@ -107,8 +107,14 @@ internal object PickerUtils {
      */
     fun List<Country>.searchForAnItem(
         searchStr: String,
+        context: Context? = null,
     ): List<Country> {
         val filteredItems = filter {
+            context?.getString(getCountryName(it.code))?.contains(
+                searchStr,
+                ignoreCase = true
+            ) ?: false
+                ||
             it.name.contains(
                 searchStr,
                 ignoreCase = true,

--- a/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/PickerUtils.kt
+++ b/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/PickerUtils.kt
@@ -110,15 +110,15 @@ internal object PickerUtils {
         context: Context? = null,
     ): List<Country> {
         val filteredItems = filter {
-            context?.getString(getCountryName(it.code))?.contains(
-                searchStr,
-                ignoreCase = true
-            ) ?: false
-                ||
-            it.name.contains(
+            context?.getString(getCountryName(it.code))?.unaccent()?.contains(
                 searchStr,
                 ignoreCase = true,
-            ) ||
+            ) ?: false
+                ||
+                it.name.unaccent().contains(
+                    searchStr,
+                    ignoreCase = true,
+                ) ||
                 it.phoneNoCode.contains(
                     searchStr,
                     ignoreCase = true,


### PR DESCRIPTION
- search doesn't allow to search country using translated name. Exemple `Switzerland` in French is `Suisse` but search can't find the country if I type "Suisse" even if the name is well displayed in French language in the list

This fixes #134 
also fixes #147 