### PR TITLE
add priority countries support in country code picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ dependencies {
 var phoneNumber by rememberSaveable { mutableStateOf("") }
 val state = rememberKomposeCountryCodePickerState(
     // limitedCountries = listOf("KE", "UG", "TZ", "RW", "SS"),
+    // priorityCountries = listOf("KE", "UG", "TZ"),
     // showCountryCode = true,
     // showCountryFlag = true,
     // defaultCountryCode = "KE",

--- a/app/src/main/java/com/joelkanyi/jcomposecountrycodepicker/MainActivity.kt
+++ b/app/src/main/java/com/joelkanyi/jcomposecountrycodepicker/MainActivity.kt
@@ -85,9 +85,10 @@ private fun PickerContent() {
         var phoneNumber by rememberSaveable { mutableStateOf("") }
         val state = rememberKomposeCountryCodePickerState(
 //            limitedCountries = listOf("KE", "UG", "TZ", "RW", "SS", "Togo", "+260", "250", "+211", "Mali", "Malawi"),
-            showCountryCode = true,
-            showCountryFlag = true,
-            defaultCountryCode = "KE",
+//            priorityCountries = listOf("SA", "KW", "BH", "QA"),
+//            showCountryCode = true,
+//            showCountryFlag = true,
+//            defaultCountryCode = "KE",
         )
 
         LazyColumn(

--- a/docs/customizations.md
+++ b/docs/customizations.md
@@ -7,6 +7,7 @@ The `state` parameter is used to set and access different variables and methods 
 ```kotlin
 val state = rememberKomposeCountryCodePickerState(
     limitedCountries = listOf("KE", "UG", "TZ", "RW", "SS", "Togo", "+260", "250", "+211", "Mali", "Malawi"),
+    priorityCountries = listOf("KE", "UG", "TZ"),
     showCountryCode = true,
     showCountryFlag = true,
     defaultCountryCode = "TZ",
@@ -15,12 +16,13 @@ val state = rememberKomposeCountryCodePickerState(
 ```
 
 ## KomposeCountryCodePickerState Customizations
-| Customization          | Description                                                                                               |
-|------------------------|-----------------------------------------------------------------------------------------------------------|
-| **showCountryCode**    | If `true`, the country code will be displayed in the country code picker `TextField`.                     |
-| **showCountryFlag**    | If `true`, the country flag will be displayed in the country code picker `TextField`.                     |
-| **defaultCountryCode** | Sets the default country code to be displayed in the country code picker.                                 |
-| **limitedCountries**   | Limits the list of countries to be displayed in the country code picker by specifying country codes, country names, or country phone codes, e.g., `listOf("KE", "UG", "TZ")`, `listOf("Kenya", "Uganda", "Tanzania")` or `listOf("+254", "+256", "+255")`. |
+| Customization          | Description                                                                                                                                                                                                                                                                                      |
+|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **showCountryCode**    | If `true`, the country code will be displayed in the country code picker `TextField`.                                                                                                                                                                                                            |
+| **showCountryFlag**    | If `true`, the country flag will be displayed in the country code picker `TextField`.                                                                                                                                                                                                            |
+| **defaultCountryCode** | Sets the default country code to be displayed in the country code picker.                                                                                                                                                                                                                        |
+| **limitedCountries**   | Limits the list of countries to be displayed in the country code picker by specifying country codes, country names, or country phone codes, e.g., `listOf("KE", "UG", "TZ")`, `listOf("Kenya", "Uganda", "Tanzania")` or `listOf("+254", "+256", "+255")`.                                       |
+| **priorityCountries**   | Specifies the priority countries to be displayed at the top of the list in the country code picker. This can be ONLY a list of country codes e.g., `listOf("KE", "UG", "TZ")`. |
 
 ## Available methods/variables accessible from the state
 

--- a/komposecountrycodepicker/api/komposecountrycodepicker.api
+++ b/komposecountrycodepicker/api/komposecountrycodepicker.api
@@ -27,6 +27,7 @@ public abstract interface class com/joelkanyi/jcomposecountrycodepicker/componen
 	public abstract fun getShowCountryCode ()Z
 	public abstract fun getShowCountryFlag ()Z
 	public abstract fun isPhoneNumberValid (Ljava/lang/String;)Z
+	public static synthetic fun isPhoneNumberValid$default (Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;Ljava/lang/String;ILjava/lang/Object;)Z
 	public abstract fun setCode (Ljava/lang/String;)V
 	public abstract fun setPhoneNo (Ljava/lang/String;)V
 }
@@ -48,7 +49,7 @@ public final class com/joelkanyi/jcomposecountrycodepicker/component/KomposeCoun
 public final class com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePickerKt {
 	public static final fun KomposeCountryCodePicker-8MMxfyk (Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ZZLandroidx/compose/ui/graphics/Shape;Lkotlin/jvm/functions/Function3;Landroidx/compose/material3/TextFieldColors;Lkotlin/jvm/functions/Function2;JJLandroidx/compose/foundation/interaction/MutableInteractionSource;Lcom/joelkanyi/jcomposecountrycodepicker/data/FlagSize;Landroidx/compose/ui/text/TextStyle;ZLandroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;Landroidx/compose/runtime/Composer;III)V
 	public static final fun qaAutomationTestTag (Landroidx/compose/ui/Modifier;Ljava/lang/String;)Landroidx/compose/ui/Modifier;
-	public static final fun rememberKomposeCountryCodePickerState (Ljava/lang/String;Ljava/util/List;ZZLandroidx/compose/runtime/Composer;II)Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;
+	public static final fun rememberKomposeCountryCodePickerState (Ljava/lang/String;Ljava/util/List;Ljava/util/List;ZZLandroidx/compose/runtime/Composer;II)Lcom/joelkanyi/jcomposecountrycodepicker/component/CountryCodePicker;
 }
 
 public final class com/joelkanyi/jcomposecountrycodepicker/data/Country {

--- a/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePicker.kt
+++ b/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/component/KomposeCountryCodePicker.kt
@@ -137,6 +137,8 @@ public interface CountryCodePicker {
  *    the text field.
  * @param limitedCountries The list of countries to be displayed in the
  *    country code picker dialog.
+ * @param priorityCountries The list of countries to be prioritized
+ *   in the country code picker dialog.
  * @param showCode If true, the country code will be shown in the text
  *    field.
  * @param showFlag If true, the country flag will be shown in the text
@@ -147,6 +149,7 @@ public interface CountryCodePicker {
 internal class CountryCodePickerImpl(
     val defaultCountryCode: String,
     val limitedCountries: List<String>,
+    val priorityCountries: List<String>,
     val showCode: Boolean,
     val showFlag: Boolean,
 ) : CountryCodePicker {
@@ -191,6 +194,15 @@ internal class CountryCodePickerImpl(
             PickerUtils.allCountries
         } else {
             PickerUtils.getLimitedCountries(limitedCountries)
+        }.let {
+            if (priorityCountries.isNotEmpty()) {
+                PickerUtils.sortCountriesWithPriority(
+                    countries = it,
+                    priorityCountries = priorityCountries,
+                )
+            } else {
+                it
+            }
         },
     )
     override val countryList: List<Country>
@@ -234,6 +246,7 @@ internal class CountryCodePickerImpl(
                 listOf(
                     it.countryCode,
                     it.limitedCountries,
+                    it.priorityCountries,
                     it.showCode,
                     it.showFlag,
                 )
@@ -242,6 +255,7 @@ internal class CountryCodePickerImpl(
                 CountryCodePickerImpl(
                     defaultCountryCode = it[0] as String,
                     limitedCountries = it[1] as List<String>,
+                    priorityCountries = it[1] as List<String>,
                     showCode = it[2] as Boolean,
                     showFlag = it[3] as Boolean,
                 )
@@ -287,6 +301,7 @@ public class KomposeCountryCodePickerDefaults(
 public fun rememberKomposeCountryCodePickerState(
     defaultCountryCode: String? = null,
     limitedCountries: List<String> = emptyList(),
+    priorityCountries: List<String> = emptyList(),
     showCountryCode: Boolean = true,
     showCountryFlag: Boolean = true,
 ): CountryCodePicker {
@@ -298,6 +313,7 @@ public fun rememberKomposeCountryCodePickerState(
         CountryCodePickerImpl(
             defaultCountryCode = countryCode.lowercase(),
             limitedCountries = limitedCountries,
+            priorityCountries = priorityCountries,
             showCode = showCountryCode,
             showFlag = showCountryFlag,
         )

--- a/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/PickerUtils.kt
+++ b/komposecountrycodepicker/src/main/java/com/joelkanyi/jcomposecountrycodepicker/utils/PickerUtils.kt
@@ -61,6 +61,32 @@ internal object PickerUtils {
     }
 
     /**
+     * [sortCountriesWithPriority] Sorts the countries list with the priority
+     * countries at the top.
+     *
+     * @param countries The list of countries to be sorted.
+     * @param priorityCountries The list of country codes that should be prioritized.
+     * @return A sorted list of countries with the priority countries at the top.
+     *
+     * Please dont alter the order of the priority countries.
+     */
+    fun sortCountriesWithPriority(
+        countries: List<Country>,
+        priorityCountries: List<String>,
+    ): List<Country> {
+        val priorityCodesLower = priorityCountries.map { it.lowercase() }
+
+        val priorityMap = priorityCodesLower.withIndex().associate { it.value to it.index }
+
+        val (priority, nonPriority) = countries.partition { it.code.lowercase() in priorityMap }
+
+        val sortedPriority = priority.sortedBy { priorityMap[it.code.lowercase()] }
+        val sortedNonPriority = nonPriority.sortedBy { it.name.lowercase() }
+
+        return sortedPriority + sortedNonPriority
+    }
+
+    /**
      * [getDefaultLangCode] Returns the default language code of the device.
      *
      * @param context The context of the activity or fragment.
@@ -73,7 +99,7 @@ internal object PickerUtils {
         countryCode.ifEmpty {
             "us"
         }
-    } catch (e: Exception) {
+    } catch (_: Exception) {
         "us"
     }
 

--- a/komposecountrycodepicker/src/test/java/com/joelkanyi/jcomposecountrycodepicker/utils/PickerUtilsTest.kt
+++ b/komposecountrycodepicker/src/test/java/com/joelkanyi/jcomposecountrycodepicker/utils/PickerUtilsTest.kt
@@ -131,4 +131,19 @@ class PickerUtilsTest {
         // Then
         assertThat(result).hasSize(5)
     }
+
+    @Test
+    fun testSortCountriesWithPriorityCountries() {
+        // Given
+        val priorityCountries = listOf("ug", "ke", "tz")
+        val countries = PickerUtils.allCountries
+
+        // When
+        val sortedCountries = PickerUtils.sortCountriesWithPriority(countries, priorityCountries)
+
+        // Then
+        assertThat(sortedCountries.map { it.phoneNoCode }.take(3)).isEqualTo(
+            listOf("+256", "+254", "+255"),
+        )
+    }
 }


### PR DESCRIPTION
Fix #135 

You can now provide a list of country codes to be prioritized at the top of the country list:
```kotlin
val state = rememberKomposeCountryCodePickerState(
    priorityCountries = listOf("KE", "UG", "TZ", "QA"),
)
```